### PR TITLE
Strip slash stdlib paths

### DIFF
--- a/include/wilton/support/script_engine_map.hpp
+++ b/include/wilton/support/script_engine_map.hpp
@@ -65,8 +65,12 @@ inline sl::io::span<const char> load_init_code() {
 inline std::string shorten_script_path(const std::string& path) {
     static sl::json::value json = load_wilton_config();
     auto& base_url = json["requireJs"]["baseUrl"].as_string_nonempty_or_throw("requireJs.baseUrl");
-    if (sl::utils::starts_with(path, base_url)) {
-        return path.substr(base_url.length());
+    if (sl::utils::starts_with(path, base_url) && path.length()) {
+        auto shortened = path.substr(base_url.length());
+        if (shortened.length() > 1 && '/' == shortened.at(0)) {
+            return shortened.substr(1);
+        }
+        return shortened;
     }
     if (sl::utils::starts_with(path, file_proto_prefix)) {
         return path.substr(file_proto_prefix.length());

--- a/include/wilton/support/script_engine_map.hpp
+++ b/include/wilton/support/script_engine_map.hpp
@@ -65,7 +65,7 @@ inline sl::io::span<const char> load_init_code() {
 inline std::string shorten_script_path(const std::string& path) {
     static sl::json::value json = load_wilton_config();
     auto& base_url = json["requireJs"]["baseUrl"].as_string_nonempty_or_throw("requireJs.baseUrl");
-    if (sl::utils::starts_with(path, base_url) && path.length()) {
+    if (sl::utils::starts_with(path, base_url)) {
         auto shortened = path.substr(base_url.length());
         if (shortened.length() > 1 && '/' == shortened.at(0)) {
             return shortened.substr(1);


### PR DESCRIPTION
JS paths for files loaded from std.wlib have leading slash prefix (that denotes an "absolute path" inside the ZIP file). Files loaded from plain FS `applicationDirectory` don't have leading slashes. 

This change strips leading slashes from ZIP-loaded paths.