### PR TITLE
use tree map for engines registry to prevent iterator invalidation

### DIFF
--- a/include/wilton/support/script_engine_map.hpp
+++ b/include/wilton/support/script_engine_map.hpp
@@ -8,10 +8,10 @@
 #ifndef WILTON_SUPPORT_SCRIPT_ENGINE_HPP
 #define WILTON_SUPPORT_SCRIPT_ENGINE_HPP
 
+#include <map>
 #include <mutex>
 #include <string>
 #include <thread>
-#include <unordered_map>
 
 #include "staticlib/config.hpp"
 #include "staticlib/io.hpp"
@@ -79,7 +79,7 @@ inline std::string shorten_script_path(const std::string& path) {
 template<typename Engine>
 class script_engine_map {
     std::mutex mutex;
-    std::unordered_map<std::string, Engine> engines;
+    std::map<std::string, Engine> engines;
     
 public:
     support::buffer run_script(sl::io::span<const char> callback_script_json) {
@@ -105,7 +105,7 @@ private:
         if (engines.end() == it) {
             auto code = script_engine_map_detail::load_init_code();
             auto se = Engine(code);
-            auto pa = engines.emplace(tid, std::move(se));
+            auto pa = engines.insert(std::make_pair(tid, std::move(se)));
             it = pa.first;
         }
         return it->second;


### PR DESCRIPTION
`script_engine_map` is a poor-man's thread-local replacement that holds JS engine instances (one per thread). It looks to be a plain error to use `std::unordered_map` there as its iterators may be invalidated on re-hash after some inserts.

This patch changes the map to `std::map`. `emplace` changed to `insert` to satisfy GCC 4.7.